### PR TITLE
chore: add SPDX Apache-2.0 license headers to source files

### DIFF
--- a/api/config_types.go
+++ b/api/config_types.go
@@ -1,18 +1,5 @@
-/*
-Copyright 2024.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
 
 package api
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/internal/cmd/help/help.go
+++ b/internal/cmd/help/help.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package help
 
 import (

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package run
 
 import (

--- a/internal/cmd/run/status.go
+++ b/internal/cmd/run/status.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package run
 
 import (

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package version
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package config
 
 import (

--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package globals
 
 import (

--- a/internal/hashring/hashring.go
+++ b/internal/hashring/hashring.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package hashring
 
 import (

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import (

--- a/internal/metrics/types.go
+++ b/internal/metrics/types.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package metrics
 
 import "github.com/prometheus/client_golang/prometheus"

--- a/internal/proxy/common.go
+++ b/internal/proxy/common.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/proxy/http.go
+++ b/internal/proxy/http.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/proxy/http2.go
+++ b/internal/proxy/http2.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 func (p *ProxyT) RunHttp2() (err error) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (

--- a/internal/proxy/synchronizer.go
+++ b/internal/proxy/synchronizer.go
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
+// SPDX-License-Identifier: Apache-2.0
+
 package proxy
 
 import (


### PR DESCRIPTION
Add the standard two-line SPDX header to every source file in the repository so
the Apache-2.0 license is machine-readable per file:

```
SPDX-FileCopyrightText: 2026 Alby Hernández <hola@achetronic.com>
SPDX-License-Identifier: Apache-2.0
```

Where a longer Apache/copyright boilerplate header already existed, it was
replaced by these two short lines. Shebangs and Go build constraints are
preserved. This is a comments-only change; the build is unaffected.
